### PR TITLE
chore: prepare v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+<!--
+  - SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## v1.3.0 - 2025-11-06
+### Changed
+* Add SPDX header ([#160](https://github.com/nextcloud-libraries/babel-config/pull/160))
+* chore: update Node and NPM versions ([#190](https://github.com/nextcloud-libraries/babel-config/pull/190))
+* docs: use consistent note about contributing and authors ([#192](https://github.com/nextcloud-libraries/babel-config/pull/192))
+* ci: update dependabot-approve-merge.yml from org ([#167](https://github.com/nextcloud-libraries/babel-config/pull/167))
+* ci: update reuse.yml workflow from template ([#188](https://github.com/nextcloud-libraries/babel-config/pull/188))
+* ci: update npm-publish.yml workflow from template ([#189](https://github.com/nextcloud-libraries/babel-config/pull/189))
+* ci: update workflows from organization ([#191](https://github.com/nextcloud-libraries/babel-config/pull/191))
+
+## v1.2.0 - 2024-05-16
+### Fixed
+* fix(deps): Pin dependencies ([#151](https://github.com/nextcloud-libraries/babel-config/pull/151))
+
+### Changed
+* Update NPM version to v10 for LTS Node 20 ([#153](https://github.com/nextcloud-libraries/babel-config/pull/153))
+* ci: Update workflows from templates ([#152](https://github.com/nextcloud-libraries/babel-config/pull/152))
+
+## v1.1.1 - 2024-04-29
+### Fixed
+* Enable transformation of class properties ([#30](https://github.com/nextcloud-libraries/babel-config/pull/30))
+
+### Changed
+* Updating npm-publish.yml workflow from template ([#31](https://github.com/nextcloud-libraries/babel-config/pull/31))
+* Updated dependencies
+
+## v1.1.0 - 2024-04-29
+### Changed
+* Remove unused dependencies ([#26](https://github.com/nextcloud-libraries/babel-config/pull/26))
+* Updated dependencies
+
+## v1.0.0 - 2024-04-29
+* Init global babel config ([#1](https://github.com/nextcloud-libraries/babel-config/pull/1))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/babel-config",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/babel-config",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@babel/core": "^7.27.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/babel-config",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Babel shared config for nextcloud apps",
   "keywords": [
     "babel",


### PR DESCRIPTION
## v1.3.0 - 2025-11-06
### Changed
* Add SPDX header ([#160](https://github.com/nextcloud-libraries/babel-config/pull/160))
* chore: update Node and NPM versions ([#190](https://github.com/nextcloud-libraries/babel-config/pull/190))
* docs: use consistent note about contributing and authors ([#192](https://github.com/nextcloud-libraries/babel-config/pull/192))
* ci: update dependabot-approve-merge.yml from org ([#167](https://github.com/nextcloud-libraries/babel-config/pull/167))
* ci: update reuse.yml workflow from template ([#188](https://github.com/nextcloud-libraries/babel-config/pull/188))
* ci: update npm-publish.yml workflow from template ([#189](https://github.com/nextcloud-libraries/babel-config/pull/189))
* ci: update workflows from organization ([#191](https://github.com/nextcloud-libraries/babel-config/pull/191))